### PR TITLE
Sync lxd-agent-loader with lxd

### DIFF
--- a/99-lxd-agent.rules
+++ b/99-lxd-agent.rules
@@ -1,1 +1,5 @@
-ACTION=="add", SYMLINK=="virtio-ports/org.linuxcontainers.lxd", TAG+="systemd", ACTION=="add", RUN+="/bin/systemctl start lxd-agent.service"
+# Start the lxd-agent.service when QEMU serial devices (symlinks in virtio-ports) appear.
+SYMLINK=="virtio-ports/com.canonical.lxd", TAG+="systemd", ENV{SYSTEMD_WANTS}+="lxd-agent.service"
+
+# Legacy serial device name for backward compatibility.
+SYMLINK=="virtio-ports/org.linuxcontainers.lxd", TAG+="systemd", ENV{SYSTEMD_WANTS}+="lxd-agent.service"

--- a/debian/control
+++ b/debian/control
@@ -2,8 +2,8 @@ Source: lxd-agent-loader
 Section: admin
 Priority: optional
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
-Standards-Version: 4.6.0.1
-Homepage: https://linuxcontainers.org/
+Standards-Version: 4.6.2
+Homepage: https://github.com/canonical/lxd
 Build-Depends: debhelper-compat (= 13)
 Rules-Requires-Root: no
 
@@ -15,5 +15,5 @@ Description: LXD - VM agent loader
  The LXD VM agent enables access to advanced LXD features such as file
  transfer and command spawning inside virtual machines run by LXD.
  .
- This package contains init scripts that will automatically load the
- agent and run it when started in a LXD VM.
+ This package will automatically load and run the agent when started in
+ a LXD VM.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,9 +1,9 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: lxd
 Upstream-Contact: lxc-devel@lists.linuxcontainers.org
-Source: https://linuxcontainers.org/lxd/downloads
+Source: https://github.com/canonical/lxd-agent-loader/
 Comment: The content of this package is synced with
- https://github.com/lxc/lxd/blob/master/lxd/instance/drivers/driver_qemu.go
+ https://github.com/canonical/lxd/blob/main/lxd/instance/drivers/driver_qemu.go
 
 Files: *
 Copyright: 2020 LXD contributors

--- a/debian/copyright
+++ b/debian/copyright
@@ -6,7 +6,7 @@ Comment: The content of this package is synced with
  https://github.com/canonical/lxd/blob/main/lxd/instance/drivers/driver_qemu.go
 
 Files: *
-Copyright: 2020 LXD contributors
+Copyright: 2023 LXD contributors
 License: Apache-2
 
 License: Apache-2

--- a/lxd-agent-setup
+++ b/lxd-agent-setup
@@ -1,4 +1,10 @@
 #!/bin/sh
+#
+# Setup script for lxd-agent that is executed by the lxd-agent systemd unit before lxd-agent is started.
+# The script sets up a temporary mount point, copies data from the mount (including lxd-agent binary),
+# and then unmounts it. It also ensures appropriate permissions for the LXD agent's runtime directory.
+#
+
 set -eu
 PREFIX="/run/lxd_agent"
 

--- a/lxd-agent.service
+++ b/lxd-agent.service
@@ -1,8 +1,10 @@
+# Systemd unit for lxd-agent. It ensures the lxd-agent is copied from the shared filesystem before
+# it is started. The service is triggered dynamically via udev rules when certain virtio-ports are
+# detected, rather than being enabled at boot.
 [Unit]
 Description=LXD - agent
-Documentation=https://linuxcontainers.org/lxd
-ConditionPathExists=/dev/virtio-ports/org.linuxcontainers.lxd
-Before=cloud-init.target cloud-init.service cloud-init-local.service
+Documentation=https://documentation.ubuntu.com/lxd/en/latest/
+Before=multi-user.target cloud-init.target cloud-init.service cloud-init-local.service
 DefaultDependencies=no
 
 [Service]
@@ -14,6 +16,3 @@ Restart=on-failure
 RestartSec=5s
 StartLimitInterval=60
 StartLimitBurst=10
-
-[Install]
-WantedBy=multi-user.target


### PR DESCRIPTION
This PR updates lxd-agent-loader to reflect the change of LXD ring buffer rename.

TODO:
- [ ] Verify all attributes in `debian/control` file and potentially other files
- [ ] Reference [comment from @simondeziel](https://github.com/canonical/lxd/pull/12548#discussion_r1403704886) about removing old symlinks
- [x] Needs a rebase once #2 is merged.
- [ ] Versioning and changelog