### PR TITLE
Prepare `lxd-agent-setup` for Ubuntu Noble

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+lxd-agent-loader (0.6) noble; urgency=medium
+
+  * Unit: Update lxd-agent systemd unit for new virtio-serial
+    device name (LP: #2044859)
+  * Unit: Small tweaks to lxd-agent systemd unit:
+    - Use readonly mounts for config drive
+    - Mount /run/lxd-agent tmpfs as nodev and nosuid
+    - Simplify config file copy to tmpfs
+
+ -- Simon Deziel <simon.deziel@canonical.com>  Mon, 27 Nov 2023 17:01:06 -0500
+
 lxd-agent-loader (0.5) jammy; urgency=medium
 
   * Units: Sync with upstream:

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: optional
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Standards-Version: 4.6.2
-Homepage: https://github.com/canonical/lxd
+Homepage: https://github.com/canonical/lxd-agent-loader
 Build-Depends: debhelper-compat (= 13)
 Rules-Requires-Root: no
 

--- a/lxd-agent-setup
+++ b/lxd-agent-setup
@@ -10,12 +10,12 @@ PREFIX="/run/lxd_agent"
 
 # Functions.
 mount_virtiofs() {
-    mount -t virtiofs config "${PREFIX}/.mnt" >/dev/null 2>&1
+    mount -t virtiofs config "${PREFIX}/.mnt" -o ro >/dev/null 2>&1
 }
 
 mount_9p() {
     modprobe 9pnet_virtio >/dev/null 2>&1 || true
-    mount -t 9p config "${PREFIX}/.mnt" -o access=0,trans=virtio >/dev/null 2>&1
+    mount -t 9p config "${PREFIX}/.mnt" -o ro,access=0,trans=virtio >/dev/null 2>&1
 }
 
 fail() {

--- a/lxd-agent-setup
+++ b/lxd-agent-setup
@@ -28,7 +28,7 @@ fail() {
 # Setup the mount target.
 umount -l "${PREFIX}" >/dev/null 2>&1 || true
 mkdir -p "${PREFIX}"
-mount -t tmpfs tmpfs "${PREFIX}" -o mode=0700,size=50M
+mount -t tmpfs tmpfs "${PREFIX}" -o mode=0700,nodev,nosuid,noatime,size=25M
 mkdir -p "${PREFIX}/.mnt"
 
 # Try virtiofs first.

--- a/lxd-agent-setup
+++ b/lxd-agent-setup
@@ -14,8 +14,8 @@ mount_virtiofs() {
 }
 
 mount_9p() {
-    /sbin/modprobe 9pnet_virtio >/dev/null 2>&1 || true
-    /bin/mount -t 9p config "${PREFIX}/.mnt" -o access=0,trans=virtio >/dev/null 2>&1
+    modprobe 9pnet_virtio >/dev/null 2>&1 || true
+    mount -t 9p config "${PREFIX}/.mnt" -o access=0,trans=virtio >/dev/null 2>&1
 }
 
 fail() {

--- a/lxd-agent-setup
+++ b/lxd-agent-setup
@@ -35,11 +35,8 @@ mkdir -p "${PREFIX}/.mnt"
 mount_virtiofs || mount_9p || fail "Couldn't mount virtiofs or 9p, failing."
 
 # Copy the data.
-cp -Ra "${PREFIX}/.mnt/"* "${PREFIX}"
+cp -Ra --no-preserve=ownership "${PREFIX}/.mnt/"* "${PREFIX}"
 
 # Unmount the temporary mount.
 umount "${PREFIX}/.mnt"
 rmdir "${PREFIX}/.mnt"
-
-# Fix up permissions.
-chown -R root:root "${PREFIX}"


### PR DESCRIPTION
This should fix #5 and #6. It also prepares the needed bits for https://bugs.launchpad.net/ubuntu/+source/lxd-agent-loader/+bug/2044859